### PR TITLE
Add Support for "Move Workspace File" API Endpoint

### DIFF
--- a/sendsafely/Package.py
+++ b/sendsafely/Package.py
@@ -13,7 +13,7 @@ from sendsafely.Progress import Progress
 import warnings
 
 from sendsafely.exceptions import CreatePackageFailedException, FinalizePackageFailedException, DownloadFileException, \
-    UploadFileException, MoveFileException, DeletePackageException, KeycodeRequiredException, GetPackageInformationFailedException, \
+    UploadFileException, DeletePackageException, KeycodeRequiredException, GetPackageInformationFailedException, \
     UploadKeycodeException, AddRecipientFailedException, UpdateRecipientFailedException, UploadMessageException, \
     GetPublicKeysFailedException, GetFileInformationException, DeleteFileException, GetPackageMessageException, \
     AddFileFailedException
@@ -274,22 +274,6 @@ class Package:
             raise AddFileFailedException(details=str(e))
         if response["response"] != "SUCCESS":
             raise AddFileFailedException(details=response["message"])
-        return response
-
-    def move_file_to_directory(self, file_id, directory_id):
-        """
-        Moves the file with the specified id to the directory with the specified ID
-        """
-        endpoint = "/package/" + self.package_id + "/directory/" + directory_id + "/file/" + file_id
-        url = self.sendsafely.BASE_URL + endpoint
-        headers = make_headers(self.sendsafely.API_SECRET, self.sendsafely.API_KEY, endpoint)
-        try:
-            response = requests.post(url=url, headers=headers).json()
-        except Exception as e:
-            raise MoveFileException(details=e)
-
-        if response["response"] != "SUCCESS":
-            raise MoveFileException(details=response["message"])
         return response
 
     def delete_file_from_package(self, file_id):

--- a/sendsafely/Package.py
+++ b/sendsafely/Package.py
@@ -13,7 +13,7 @@ from sendsafely.Progress import Progress
 import warnings
 
 from sendsafely.exceptions import CreatePackageFailedException, FinalizePackageFailedException, DownloadFileException, \
-    UploadFileException, DeletePackageException, KeycodeRequiredException, GetPackageInformationFailedException, \
+    UploadFileException, MoveFileException, DeletePackageException, KeycodeRequiredException, GetPackageInformationFailedException, \
     UploadKeycodeException, AddRecipientFailedException, UpdateRecipientFailedException, UploadMessageException, \
     GetPublicKeysFailedException, GetFileInformationException, DeleteFileException, GetPackageMessageException, \
     AddFileFailedException
@@ -274,6 +274,22 @@ class Package:
             raise AddFileFailedException(details=str(e))
         if response["response"] != "SUCCESS":
             raise AddFileFailedException(details=response["message"])
+        return response
+
+    def move_file_to_directory(self, file_id, directory_id):
+        """
+        Moves the file with the specified id to the directory with the specified ID
+        """
+        endpoint = "/package/" + self.package_id + "/directory/" + directory_id + "/file/" + file_id
+        url = self.sendsafely.BASE_URL + endpoint
+        headers = make_headers(self.sendsafely.API_SECRET, self.sendsafely.API_KEY, endpoint)
+        try:
+            response = requests.post(url=url, headers=headers).json()
+        except Exception as e:
+            raise MoveFileException(details=e)
+
+        if response["response"] != "SUCCESS":
+            raise MoveFileException(details=response["message"])
         return response
 
     def delete_file_from_package(self, file_id):

--- a/sendsafely/SendSafely.py
+++ b/sendsafely/SendSafely.py
@@ -14,7 +14,7 @@ from pgpy import PGPMessage
 from pgpy.constants import KeyFlags, HashAlgorithm, SymmetricKeyAlgorithm, CompressionAlgorithm, PubKeyAlgorithm
 from sendsafely.Package import Package
 from sendsafely.exceptions import GetPackagesException, GetUserInformationException, TrustedDeviceException, \
-    DeletePackageException, GetPackageInformationFailedException, GetKeycodeFailedException
+    DeletePackageException, GetPackageInformationFailedException, GetKeycodeFailedException, MoveFileException
 from sendsafely.utilities import make_headers, _get_string_from_file
 
 
@@ -268,3 +268,19 @@ class SendSafely:
                 row_index += page_size
         except Exception as e:
             GetPackagesException(details=str(e))
+
+    def move_file(self, package_id, file_id, destination_directory_id):
+        """
+        Moves the file with the specified id to the directory with the specified ID
+        """
+        endpoint = "/package/" + package_id + "/directory/" + destination_directory_id + "/file/" + file_id
+        url = self.BASE_URL + endpoint
+        headers = make_headers(self.API_SECRET, self.API_KEY, endpoint)
+        try:
+            response = requests.post(url=url, headers=headers).json()
+        except Exception as e:
+            raise MoveFileException(details=e)
+
+        if response["response"] != "SUCCESS":
+            raise MoveFileException(details=response["message"])
+        return response

--- a/sendsafely/exceptions.py
+++ b/sendsafely/exceptions.py
@@ -44,6 +44,17 @@ class DeleteFileException(Exception):
             display = self.message
         super().__init__(display)
 
+class MoveFileException(Exception):
+    """Exception raised during file movement.
+    """
+    def __init__(self, details=None):
+        self.message = "An error occurred during file movement."
+        self.details = details
+        display = self.details
+        if display is None:
+            display = self.message
+        super().__init__(display)
+
 
 class FinalizePackageFailedException(Exception):
     """Exception raised while finalizing package.


### PR DESCRIPTION
**Summary:**
This pull request introduces an ad-hoc implementation to interact with an additional endpoint of the SendSafely API that is currently not supported by this package. The existing Python package for SendSafely does not expose this endpoint, so I’ve implemented the necessary functionality to support interactions with it. This was added based on our specific needs for file management within workspaces.

**Changes Made:**
- Added a new method to the Package class to interact with the previously unsupported "Move Workspace File" API endpoint.
- Added the corresponding exception class MoveFileException to handle errors related to this operation.

**Notes:**
- The additions are:
  - `Package.move_file_to_directory(self, file_id, directory_id)`
  - `class MoveFileException`
  These were named in alignment with the existing methods in the package. However, there are some inconsistencies across the documentation:
    - In the [rest-api-docs.sendsafely.com - POST Move Workspace File](https://rest-api-docs.sendsafely.com/#df647878-884f-4f5f-8fdb-291c4c746d47), the endpoint is named **Move Workspace File**.
    - In the [JavaScript Client for Node.js](https://developer.sendsafely.com/javascript/api.htm), the method for moving a directory within a workspace is named **updateDirectory**.
    
  These naming variations are noted for consistency with the rest of the package, but I believe the current names are clear and follow the existing patterns in the package.